### PR TITLE
Chore: fix publish registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@transmission-dynamics/react-native-paper",
-  "version": "5.13.1-td.1.0.0",
+  "version": "5.13.1-td.1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@transmission-dynamics/react-native-paper",
-      "version": "5.13.1-td.1.0.0",
+      "version": "5.13.1-td.1.0.1",
       "license": "MIT",
       "dependencies": {
         "@callstack/react-theme-provider": "^3.0.9",

--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
     "docs": "yarn --cwd docs",
     "example": "yarn --cwd example"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
   "dependencies": {
     "@callstack/react-theme-provider": "^3.0.9",
     "color": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmission-dynamics/react-native-paper",
-  "version": "5.13.1-td.1.0.0",
+  "version": "5.13.1-td.1.0.1",
   "description": "Material design for React Native",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
Needed to remove `publishConfig` from `package.json` file to be able to deploy the library to AWS CodeArtifact